### PR TITLE
Bugfixes

### DIFF
--- a/SQLiteTurbo/SQLiteTurbo.csproj
+++ b/SQLiteTurbo/SQLiteTurbo.csproj
@@ -90,16 +90,16 @@
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Data" />
-    <Reference Include="System.Data.SQLite, Version=1.0.104.0, Culture=neutral, PublicKeyToken=db937bc2d44ff139, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Data.SQLite.Core.1.0.104.0\lib\net46\System.Data.SQLite.dll</HintPath>
+    <Reference Include="System.Data.SQLite, Version=1.0.108.0, Culture=neutral, PublicKeyToken=db937bc2d44ff139, processorArchitecture=x86">
+      <HintPath>..\packages\System.Data.SQLite.x86.1.0.108.0\lib\net46\System.Data.SQLite.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Data.SQLite.EF6, Version=1.0.104.0, Culture=neutral, PublicKeyToken=db937bc2d44ff139, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Data.SQLite.EF6.1.0.104.0\lib\net46\System.Data.SQLite.EF6.dll</HintPath>
+    <Reference Include="System.Data.SQLite.EF6, Version=1.0.108.0, Culture=neutral, PublicKeyToken=db937bc2d44ff139, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Data.SQLite.EF6.1.0.108.0\lib\net46\System.Data.SQLite.EF6.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Data.SQLite.Linq, Version=1.0.104.0, Culture=neutral, PublicKeyToken=db937bc2d44ff139, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Data.SQLite.Linq.1.0.104.0\lib\net46\System.Data.SQLite.Linq.dll</HintPath>
+    <Reference Include="System.Data.SQLite.Linq, Version=1.0.108.0, Culture=neutral, PublicKeyToken=db937bc2d44ff139, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Data.SQLite.Linq.1.0.108.0\lib\net46\System.Data.SQLite.Linq.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Deployment" />
@@ -448,11 +448,11 @@
     <PostBuildEvent>
     </PostBuildEvent>
   </PropertyGroup>
-  <Import Project="..\packages\System.Data.SQLite.Core.1.0.104.0\build\net46\System.Data.SQLite.Core.targets" Condition="Exists('..\packages\System.Data.SQLite.Core.1.0.104.0\build\net46\System.Data.SQLite.Core.targets')" />
+  <Import Project="..\packages\System.Data.SQLite.Core.1.0.108.0\build\net46\System.Data.SQLite.Core.targets" Condition="Exists('..\packages\System.Data.SQLite.Core.1.0.108.0\build\net46\System.Data.SQLite.Core.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+      <ErrorText>Dieses Projekt verweist auf mindestens ein NuGet-Paket, das auf diesem Computer fehlt. Verwenden Sie die Wiederherstellung von NuGet-Paketen, um die fehlenden Dateien herunterzuladen. Weitere Informationen finden Sie unter "http://go.microsoft.com/fwlink/?LinkID=322105". Die fehlende Datei ist "{0}".</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\System.Data.SQLite.Core.1.0.104.0\build\net46\System.Data.SQLite.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\System.Data.SQLite.Core.1.0.104.0\build\net46\System.Data.SQLite.Core.targets'))" />
+    <Error Condition="!Exists('..\packages\System.Data.SQLite.Core.1.0.108.0\build\net46\System.Data.SQLite.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\System.Data.SQLite.Core.1.0.108.0\build\net46\System.Data.SQLite.Core.targets'))" />
   </Target>
 </Project>

--- a/SQLiteTurbo/TableChanges.cs
+++ b/SQLiteTurbo/TableChanges.cs
@@ -1047,10 +1047,10 @@ namespace SQLiteTurbo
                     {
                         try
                         {
-                            SQLiteConnectionStringBuilder sb = new SQLiteConnectionStringBuilder(_main.ConnectionString);
-                            string fpath = sb.DataSource;
-							_main.Close();
-							_main.Dispose();
+                            //SQLiteConnectionStringBuilder sb = new SQLiteConnectionStringBuilder(_main.ConnectionString);
+                            string fpath = _main.DataSource;
+                            _main.Close();
+                            _main.Dispose();
                             _main = null;
                             if (!_inmemory)
                                 File.Delete(fpath);

--- a/SQLiteTurbo/TableDiffControl.cs
+++ b/SQLiteTurbo/TableDiffControl.cs
@@ -545,6 +545,7 @@ namespace SQLiteTurbo
             {
                 if (otherBlob != null && (citem.Result == ComparisonResult.Same || citem.Result == ComparisonResult.DifferentData))
                 {
+                    /*
                     if (otherBlob is long)
                     {
                         // Another adjustment for the other BLOB field value
@@ -552,11 +553,19 @@ namespace SQLiteTurbo
                         if (ob == 0) // means NULL blob field
                             otherBlob = DBNull.Value;
                     }
+                    */
+                    if (Utils.GetDbType(column.ColumnType) == DbType.Binary)
+                    {
+                        if (otherBlob.Equals("0"))
+                            otherBlob = DBNull.Value;
+                    }
+
                 }
 
                 if (value != DBNull.Value)
                 {
-                    string fpath = null;
+                    //string fpath = null;
+                    string fpath = Configuration.TempBlobFilePath;
                     long blobLength = 0;
                     if (value is Be.Windows.Forms.DynamicFileByteProvider)
                     {
@@ -599,7 +608,8 @@ namespace SQLiteTurbo
 
                     // Update the table change item with an indication that the BLOB field that was just saved
                     // is not null.
-                    citem.SetField(column.ObjectName.ToString(), !right, (long)1);
+                    //citem.SetField(column.ObjectName.ToString(), !right, (long)1);
+                    citem.SetField(column.ObjectName.ToString(), !right, "1");
 
                     if (otherBlob != null && (citem.Result == ComparisonResult.DifferentData || citem.Result == ComparisonResult.Same))
                     {

--- a/SQLiteTurbo/TableDiffControl.cs
+++ b/SQLiteTurbo/TableDiffControl.cs
@@ -503,8 +503,9 @@ namespace SQLiteTurbo
             // in order to avoid loading the BLOB field into main memory.
             if (Utils.GetDbType(column.ColumnType) == DbType.Binary)
             {
-                long v = (long)value;
-                if (v == 0) // means NULL
+                //long v = (long)value;
+                //if (v == 0) // means NULL
+                if (value.Equals("0"))
                     value = DBNull.Value;
             }
 
@@ -815,8 +816,9 @@ namespace SQLiteTurbo
                     }
                     else if (Utils.GetDbType(col.ColumnType) == DbType.Binary)
                     {
-                        long v = (long)fval;
-                        if (v == 1)
+                        //long v = (long)fval;
+                        //if (v == 1)
+                        if (fval.Equals("1"))
                             row.Cells[i].Value = "BLOB";
                         else
                             row.Cells[i].Value = "NULL";

--- a/SQLiteTurbo/packages.config
+++ b/SQLiteTurbo/packages.config
@@ -5,8 +5,9 @@
   <package id="EntityFramework" version="6.1.3" targetFramework="net46" />
   <package id="log4net" version="2.0.5" targetFramework="net46" />
   <package id="MultiPanelControl" version="1.1.4.0" targetFramework="net46" />
-  <package id="System.Data.SQLite" version="1.0.104.0" targetFramework="net46" />
-  <package id="System.Data.SQLite.Core" version="1.0.104.0" targetFramework="net46" />
-  <package id="System.Data.SQLite.EF6" version="1.0.104.0" targetFramework="net46" />
-  <package id="System.Data.SQLite.Linq" version="1.0.104.0" targetFramework="net46" />
+  <package id="System.Data.SQLite" version="1.0.108.0" targetFramework="net46" />
+  <package id="System.Data.SQLite.Core" version="1.0.108.0" targetFramework="net46" />
+  <package id="System.Data.SQLite.EF6" version="1.0.108.0" targetFramework="net46" />
+  <package id="System.Data.SQLite.Linq" version="1.0.108.0" targetFramework="net46" />
+  <package id="System.Data.SQLite.x86" version="1.0.108.0" targetFramework="net46" />
 </packages>

--- a/SQLiteTurboDiff.sln
+++ b/SQLiteTurboDiff.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.25928.0
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "SolutionItems", "SolutionItems", "{0C4D8682-3D2A-4367-AA71-020DFCEFA65E}"
 	ProjectSection(SolutionItems) = preProject
@@ -76,41 +76,75 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{16ADD088-AE2A-4D2D-B66C-00ED4D94EC3D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{16ADD088-AE2A-4D2D-B66C-00ED4D94EC3D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{16ADD088-AE2A-4D2D-B66C-00ED4D94EC3D}.Debug|x86.ActiveCfg = Debug|x86
+		{16ADD088-AE2A-4D2D-B66C-00ED4D94EC3D}.Debug|x86.Build.0 = Debug|x86
 		{16ADD088-AE2A-4D2D-B66C-00ED4D94EC3D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{16ADD088-AE2A-4D2D-B66C-00ED4D94EC3D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{16ADD088-AE2A-4D2D-B66C-00ED4D94EC3D}.Release|x86.ActiveCfg = Release|x86
+		{16ADD088-AE2A-4D2D-B66C-00ED4D94EC3D}.Release|x86.Build.0 = Release|x86
 		{31E951ED-11C2-46AA-BE8C-6D954698549E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{31E951ED-11C2-46AA-BE8C-6D954698549E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{31E951ED-11C2-46AA-BE8C-6D954698549E}.Debug|x86.ActiveCfg = Debug|x86
+		{31E951ED-11C2-46AA-BE8C-6D954698549E}.Debug|x86.Build.0 = Debug|x86
 		{31E951ED-11C2-46AA-BE8C-6D954698549E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{31E951ED-11C2-46AA-BE8C-6D954698549E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{31E951ED-11C2-46AA-BE8C-6D954698549E}.Release|x86.ActiveCfg = Release|x86
+		{31E951ED-11C2-46AA-BE8C-6D954698549E}.Release|x86.Build.0 = Release|x86
 		{C21121C8-A6BA-4DA7-95C8-5AA57E165F6C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{C21121C8-A6BA-4DA7-95C8-5AA57E165F6C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C21121C8-A6BA-4DA7-95C8-5AA57E165F6C}.Debug|x86.ActiveCfg = Debug|x86
+		{C21121C8-A6BA-4DA7-95C8-5AA57E165F6C}.Debug|x86.Build.0 = Debug|x86
 		{C21121C8-A6BA-4DA7-95C8-5AA57E165F6C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C21121C8-A6BA-4DA7-95C8-5AA57E165F6C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C21121C8-A6BA-4DA7-95C8-5AA57E165F6C}.Release|x86.ActiveCfg = Release|x86
+		{C21121C8-A6BA-4DA7-95C8-5AA57E165F6C}.Release|x86.Build.0 = Release|x86
 		{310E7EA3-7370-4A28-9EA6-450B35E84C7C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{310E7EA3-7370-4A28-9EA6-450B35E84C7C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{310E7EA3-7370-4A28-9EA6-450B35E84C7C}.Debug|x86.ActiveCfg = Debug|x86
+		{310E7EA3-7370-4A28-9EA6-450B35E84C7C}.Debug|x86.Build.0 = Debug|x86
 		{310E7EA3-7370-4A28-9EA6-450B35E84C7C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{310E7EA3-7370-4A28-9EA6-450B35E84C7C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{310E7EA3-7370-4A28-9EA6-450B35E84C7C}.Release|x86.ActiveCfg = Release|x86
+		{310E7EA3-7370-4A28-9EA6-450B35E84C7C}.Release|x86.Build.0 = Release|x86
 		{F71FACA5-08C3-40BA-AF53-B61291A6570C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{F71FACA5-08C3-40BA-AF53-B61291A6570C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F71FACA5-08C3-40BA-AF53-B61291A6570C}.Debug|x86.ActiveCfg = Debug|x86
+		{F71FACA5-08C3-40BA-AF53-B61291A6570C}.Debug|x86.Build.0 = Debug|x86
 		{F71FACA5-08C3-40BA-AF53-B61291A6570C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F71FACA5-08C3-40BA-AF53-B61291A6570C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F71FACA5-08C3-40BA-AF53-B61291A6570C}.Release|x86.ActiveCfg = Release|x86
+		{F71FACA5-08C3-40BA-AF53-B61291A6570C}.Release|x86.Build.0 = Release|x86
 		{B3501575-9F71-4574-99F5-6E6231AD8FD4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{B3501575-9F71-4574-99F5-6E6231AD8FD4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B3501575-9F71-4574-99F5-6E6231AD8FD4}.Debug|x86.ActiveCfg = Debug|x86
+		{B3501575-9F71-4574-99F5-6E6231AD8FD4}.Debug|x86.Build.0 = Debug|x86
 		{B3501575-9F71-4574-99F5-6E6231AD8FD4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B3501575-9F71-4574-99F5-6E6231AD8FD4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B3501575-9F71-4574-99F5-6E6231AD8FD4}.Release|x86.ActiveCfg = Release|x86
+		{B3501575-9F71-4574-99F5-6E6231AD8FD4}.Release|x86.Build.0 = Release|x86
 		{6CEE8102-55B6-42B8-AD74-2246AEB2D942}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{6CEE8102-55B6-42B8-AD74-2246AEB2D942}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6CEE8102-55B6-42B8-AD74-2246AEB2D942}.Debug|x86.ActiveCfg = Debug|x86
+		{6CEE8102-55B6-42B8-AD74-2246AEB2D942}.Debug|x86.Build.0 = Debug|x86
 		{6CEE8102-55B6-42B8-AD74-2246AEB2D942}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6CEE8102-55B6-42B8-AD74-2246AEB2D942}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6CEE8102-55B6-42B8-AD74-2246AEB2D942}.Release|x86.ActiveCfg = Release|x86
+		{6CEE8102-55B6-42B8-AD74-2246AEB2D942}.Release|x86.Build.0 = Release|x86
 		{34DD929F-BA21-4A80-AA93-114AFCC15EE7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{34DD929F-BA21-4A80-AA93-114AFCC15EE7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{34DD929F-BA21-4A80-AA93-114AFCC15EE7}.Debug|x86.ActiveCfg = Debug|x86
+		{34DD929F-BA21-4A80-AA93-114AFCC15EE7}.Debug|x86.Build.0 = Debug|x86
 		{34DD929F-BA21-4A80-AA93-114AFCC15EE7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{34DD929F-BA21-4A80-AA93-114AFCC15EE7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{34DD929F-BA21-4A80-AA93-114AFCC15EE7}.Release|x86.ActiveCfg = Release|x86
+		{34DD929F-BA21-4A80-AA93-114AFCC15EE7}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
* Bugfix (shuebener/SQLiteCompare, Issue#1)
IOException (temporary DB) when closing the program

* Bugfix: Invalid cast causes Program crash
An invalid type cast occured, when comparing columns of datatype BLOB and additional when examining theses BLOBS.

* Bugfix: sqlite3_open_v2 not supported
Added package "System.Data.SQLite.x86" which only supports sqlite3_open_v2().
Drawback: Only works for x86 compilation!

Updated further:
  <package id="System.Data.SQLite" version="1.0.108.0" targetFramework="net46" />
  <package id="System.Data.SQLite.Core" version="1.0.108.0" targetFramework="net46" />
  <package id="System.Data.SQLite.EF6" version="1.0.108.0" targetFramework="net46" />
  <package id="System.Data.SQLite.Linq" version="1.0.108.0" targetFramework="net46" />
  <package id="System.Data.SQLite.x86" version="1.0.108.0" targetFramework="net46" />
