### PR TITLE
bugFix: CaseItem Equals always false

### DIFF
--- a/SQLiteParser/SQLiteCaseItem.cs
+++ b/SQLiteParser/SQLiteCaseItem.cs
@@ -40,7 +40,7 @@ namespace SQLiteParser
             if (!RefCompare.CompareMany(_when, dst._when, _then, dst._then))
                 return false;
 
-            return base.Equals(obj);
+            return true;
         }
 
         public override string ToString()


### PR DESCRIPTION
If you have a sqlite view with a case expression, the case item comparison always return false, hence the view is always seen as different.
That's because base.Equals compare the objects by reference.